### PR TITLE
Clean up unused method overrides

### DIFF
--- a/src/Plugin/Field/FieldFormatter/QRCodeLinkFieldFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/QRCodeLinkFieldFormatter.php
@@ -20,33 +20,6 @@ use Drupal\Core\Form\FormStateInterface;
  * )
  */
 class QRCodeLinkFieldFormatter extends FormatterBase {
-  /**
-   * {@inheritdoc}
-   */
-  public static function defaultSettings() {
-    return array(
-      // Implement default settings.
-    ) + parent::defaultSettings();
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function settingsForm(array $form, FormStateInterface $form_state) {
-    return array(
-      // Implement settings form.
-    ) + parent::settingsForm($form, $form_state);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function settingsSummary() {
-    $summary = [];
-    // Implement settings summary.
-
-    return $summary;
-  }
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
Especially with using a generator like dc, any methods that you don't end up using, should be removed to avoid code bloat etc.
